### PR TITLE
Initial lambda config docs, fix links in test writing doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,25 @@
-# autograph-monitor
-An AWS lambda for checking Autograph signing is working correctly. This exercises the signature verification code in Firefox via XPCShell using the TLS-Canary tooling.
+# autograph-canary
+An AWS lambda for running Firefox / Autograph integration tests. This exercises the actual Firefox client code via XPConnect, making use of the TLS-Canary tooling.
 
 # Usage:
 ## Command line
-Ensure you have tls-canary installed correctly (e.g. via pip), then:
+To run the default set of autograph-canary tests, ensure you have tls-canary installed correctly (e.g. via `pip install tls-canary`), then:
 
-```$ autograph.py```
+```bash
+autograph.py
+```
+
+## Packaging the AWS Lambda
+TODO
 
 ## AWS lambda
-Instructions to follow...
+There are a few settings you need to think about when configuring an autograph-canary lamdba:
+1. Memory. The lambda will download, extract and execute a full build of Firefox. Firefox more memory than an AWS Lambda is allocated by default. The lambda with a current (early 2020) version of Firefox runs happily in 1024MB.
+2. Environment. The test runner itself does not rely on any specific environment to run - but the tests do. Test configuration is performed through the environment that's passed through from the lambda_context. Inspect the table below on the variables expected by the various tests and ensure these are set appropriately in your deployment:
+
+### Environment Varables
+Individual tests will need specific environment variables to be set.
+
+Variable | Description | Used By
+signed_XPI | The URL of a signed XPI for addon signature testing. A signed XPI is needed to ensure that signatures verify correctly and signed addons are correctly installed. | addon_signature_test.js
+unsigned_XPI | The URL of an unsigned XPI for addon signature testing. An unsigned XPI is needed to check that unsigned addons are appropriately rejected by Firefox. | addon_signature_test.js

--- a/doc/writing_tests.md
+++ b/doc/writing_tests.md
@@ -1,6 +1,6 @@
 # Writing Tests
 
-Autograph monitor tests run inside [XPCShell]:https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_bindings/XPConnect/xpcshell. They are a little different to [XPCShell tests]:https://developer.mozilla.org/en-US/docs/Mozilla/QA/Writing_xpcshell-based_unit_tests you may have seen before in
+Autograph monitor tests run inside [XPCShell](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Language_bindings/XPConnect/xpcshell). They are a little different to [XPCShell tests](https://developer.mozilla.org/en-US/docs/Mozilla/QA/Writing_xpcshell-based_unit_tests) you may have seen before in
 some important ways:
 - There is no xpcshell.ini and special filenames(e.g. starting test_) are not needed. Any regular file in the tests directory will be executed
 - You should not assume that any of the special configuration options or flags needed for regular XPCShell tests are set.


### PR DESCRIPTION
Fixes issue #8 -  plus a problem with link formatting in the test writing documentation