### PR TITLE
WIP - Preparing for usage in Lambda

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
+venv
 .venv
+*.zip

--- a/autograph.py
+++ b/autograph.py
@@ -84,7 +84,7 @@ def run_tests(event, lambda_context, native = False):
     # TODO: MDG check args for user specified test path.
     # TODO: MDG get a path relative to *this script* for the default test path
     test_path = os.path.abspath("tests")
-    
+
     script_files = []
     if os.path.isdir(test_path):
         children = os.listdir(test_path)
@@ -127,6 +127,9 @@ def run_tests(event, lambda_context, native = False):
         logger.info("Tests passed successfully")
     else:
         sys.exit(1)
+
+def autograph_canary_monitor(event, context):
+    run_tests(event, context, native = True)
 
 if __name__ == "__main__":
     # simulate the lambda when run from a main program

--- a/bin/package.sh
+++ b/bin/package.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+ENV=${ENV:-autographstage}
+STACK_ID=${STACK_ID:-test}
+ARTIFACT_NAME=${ARTIFACT_NAME:-"autograph-canary-monitor-${STACK_ID}-${ENV}.zip"}
+PROJECT_ROOT="$( cd "$(dirname "$0")/.." >/dev/null 2>&1 ; pwd -P )"
+cd $PROJECT_ROOT
+
+if [ ! -d 'venv' ]; then
+  python3 -m venv venv
+fi
+
+source venv/bin/activate
+pip install -r requirements.txt
+
+pushd venv/lib/python3.7/site-packages
+zip -r "${OLDPWD}/${ARTIFACT_NAME}" .
+popd
+zip -r -g "${ARTIFACT_NAME}" autograph.py tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+coloredlogs
+requests
+../tls-canary


### PR DESCRIPTION
- Add handler for lambda in autograph.py
- `requirements.txt` with no version constraints
- bin/package.sh to create zip file needed by lambda runtime

A couple problems that I ran into and need to be resolved:
1.  The lambda runtime does not have a 7zip binary available.  Is there a python module you can use instead?  If not, it is technically possible to extract a binary from amazon linux and package with the lambda I would like to avoid that.
2.  The current release available from pip for tls-canary does not have an `__init__.py` in the tools directory, so I had to run the test build from a local copy of master (see `../tls-canary` in `requirements.txt`)
3.  Actual version locks in `requirements.txt`
4. I tested with python3.7, is that ok?