### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ An AWS lambda for running Firefox / Autograph integration tests. This exercises 
 
 # Usage:
 ## Command line
-To run the default set of autograph-canary tests, ensure you have tls-canary installed correctly (e.g. via `pip install tls-canary`), then:
+To run the default set of autograph-canary tests, ensure you have tls-canary installed correctly (e.g. via `pip install tlscanary`), then:
 
 ```bash
 autograph.py


### PR DESCRIPTION
fix dash in tls-canary package name (should be tlscanary) for https://pypi.org/project/tlscanary/ not https://pypi.org/project/tls-canary/ which 404s