### PR TITLE
clean up tmp dirs

### DIFF
--- a/autograph.py
+++ b/autograph.py
@@ -143,8 +143,12 @@ def run_tests(event, lambda_context, native=False):
                 )
                 w.spawn()
                 info_response = sync_send(w, xw.Command("get_worker_info", id=1))
-                logger.info(f"running test {str(script_path.resolve())} with {test_kwargs}")
-                response = sync_send(w, xw.Command(mode="run_test", id=2, **test_kwargs))
+                logger.info(
+                    f"running test {str(script_path.resolve())} with {test_kwargs}"
+                )
+                response = sync_send(
+                    w, xw.Command(mode="run_test", id=2, **test_kwargs)
+                )
                 time.sleep(test_timeout)
                 w.terminate()
 

--- a/autograph.py
+++ b/autograph.py
@@ -99,6 +99,31 @@ def sync_send(worker, command):
     raise Exception("Message timed out")
 
 
+def log_test_messages(res_dict: typing.Dict[str, str]):
+    """
+    print log lines from run test results
+    """
+    if (
+        "result" in res_dict
+        and "results" in res_dict["result"]
+        and isinstance(res_dict["result"]["results"], list)
+    ):
+        for result in res_dict["result"]["results"]:
+            if (
+                isinstance(result, dict)
+                and "messages" in result
+                and isinstance(result["messages"], list)
+            ):
+                for line in result["messages"]:
+                    logger.info(line)
+            else:
+                logger.info(result)
+    else:
+        logger.info(res_dict)
+
+    logger.info(f"Worker info: {info_response.as_dict()}")
+
+
 def run_tests(event, lambda_context, native=False):
     coloredlogs.install(level=os.environ["CANARY_LOG_LEVEL"])
 
@@ -134,22 +159,7 @@ def run_tests(event, lambda_context, native=False):
 
         res_dict = response.as_dict()
 
-        # print log lines when possible
-        if (
-            "result" in res_dict
-            and "results" in res_dict["result"]
-            and isinstance(res_dict["result"]["results"], list)
-        ):
-            for result in res_dict["result"]["results"]:
-                if isinstance(result, dict) and "messages" in result and isinstance(result["messages"], list):
-                    for line in result["messages"]:
-                        logger.info(line)
-                else:
-                    logger.info(result)
-        else:
-            logger.info(res_dict)
-
-        logger.info(f"Worker info: {info_response.as_dict()}")
+        log_test_messages(res_dict)
 
         if res_dict["success"]:
             logger.info(

--- a/autograph.py
+++ b/autograph.py
@@ -20,8 +20,6 @@ from tlscanary.tools import firefox_downloader as fx_dl
 from tlscanary.tools import firefox_extractor as fx_ex
 from tlscanary.tools import xpcshell_worker as xw
 
-tmp_dir = None
-module_dir = None
 
 # Initialize coloredlogs
 logging.Formatter.converter = time.gmtime
@@ -30,17 +28,6 @@ coloredlogs.DEFAULT_LOG_FORMAT = (
     "%(asctime)s %(levelname)s %(threadName)s %(name)s %(message)s"
 )
 coloredlogs.install(level="DEBUG")
-
-# TODO: MDG - Move create_tempdir to a helper module
-def __create_tempdir(prefix="canary_"):
-    """
-    Helper function for creating the temporary directory.
-    Writes to the global variable tmp_dir
-    :return: Path of temporary directory
-    """
-    temp_dir = tempfile.mkdtemp(prefix=prefix)
-    logger.debug(f"Created temp dir {temp_dir!r}")
-    return temp_dir
 
 
 def get_app(temp_dir, native):


### PR DESCRIPTION
The AWS lambda runtime persists container and the ephemeral `/tmp` volume.

This PR switches to context managers to clean up after ourselves and fix `FileNotFoundError: [Errno 2] No usable temporary directory found in ...` errors.