### PR TITLE
log tmp disk usage

### DIFF
--- a/autograph.py
+++ b/autograph.py
@@ -103,8 +103,6 @@ def log_test_messages(res_dict: typing.Dict[str, str]):
     else:
         logger.info(res_dict)
 
-    logger.info(f"Worker info: {info_response.as_dict()}")
-
 
 def log_disk_usage(path: str = "/tmp"):
     """
@@ -163,6 +161,7 @@ def run_tests(event, lambda_context):
             res_dict = response.as_dict()
 
             log_test_messages(res_dict)
+            logger.info(f"Worker info: {info_response.as_dict()}")
 
             if res_dict["success"]:
                 logger.info(


### PR DESCRIPTION
debug source of 'OSError: [Errno 28] No space left on device'

lambda has a 512 MB ephemeral disk limit
https://docs.aws.amazon.com/lambda/latest/dg/gettingstarted-limits.html

lambda metrics insights provides tmp_used from embedded metric format
structured logs but it's unclear that it works in a containerized
lambda and the emf library looks unmaintained

https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Lambda-Insights-metrics.html