### PR TITLE
Fix tmp size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,16 +7,20 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
 
-# Install aws-lambda-cpp build dependencies
+# Install aws-lambda-cpp build dependencies and curl to download Fx
 RUN apt-get update && \
   apt-get install -y \
   g++ \
   make \
   cmake \
   unzip \
-  libcurl4-openssl-dev
+  libcurl4-openssl-dev \
+  curl
 
-RUN mkdir -p ${FUNCTION_DIR}/tests
+RUN mkdir -p ${FUNCTION_DIR}/tests ${FUNCTION_DIR}/firefox && \
+    cd ${FUNCTION_DIR}/firefox && \
+    curl -sSf -o - --proto '=https' --tlsv1.2 -L 'https://download.mozilla.org/?product=firefox-nightly-latest&os=linux64&lang=en-US' | \
+    tar xvjf -
 
 ADD requirements.txt ${FUNCTION_DIR}
 
@@ -43,7 +47,7 @@ ENV CSIG_COLLECTIONS="blocklists/gfx,blocklists/addons-bloomfilters,blocklists/p
 # Include global arg in this stage of the build
 ARG FUNCTION_DIR
 
-# install fx release w/ deps and 7zip for tls-canary
+# install fx release w/ deps
 RUN apt-get update \
     && echo 'deb http://deb.debian.org/debian unstable main' > /etc/apt/sources.list.d/unstable.list \
     && apt update \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,11 @@
 version: "3"
 volumes:
   tmpdir:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      o: "size=512m"
+      device: ":/tmp"
 services:
   canary:
     container_name: autograph-canary

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 awslambdaric==1.0.0
 coloredlogs==15.0
-requests==2.25.1
 git+https://github.com/mozilla/tls-canary.git#egg=tlscanary


### PR DESCRIPTION
Fix: #27 

Changes:
* limit tmp volume size to 512 MB to match AWS lambda runtime env
* bake Fx nightly into the build to avoid downloading and extracting it every run for #27 and to address /tmp size limitations with multiple concurrent executions. Trades startup and execution time for needing to rebuild and redeploy to track nightly