### PR TITLE
Test fx wo python

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN pip install --target ${FUNCTION_DIR} -r ${FUNCTION_DIR}/requirements.txt
 # add function code
 ADD autograph.py ${FUNCTION_DIR}
 COPY tests ${FUNCTION_DIR}/tests
+COPY bin ${FUNCTION_DIR}/bin
 
 FROM python:3.8-buster
 ENV DEBIAN_FRONTEND=noninteractive

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,4 +64,4 @@ ADD version.json /app/
 # Copy in the built dependencies
 COPY --from=build-image ${FUNCTION_DIR} ${FUNCTION_DIR}
 
-CMD [ "/usr/local/bin/python", "autograph.py" ]
+CMD [ "/function/bin/canary_fx_test.sh" ]

--- a/bin/canary_fx_test.sh
+++ b/bin/canary_fx_test.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -ev
+set -o pipefail
+
+/function/firefox/firefox/firefox -xpcshell -g /function/firefox/firefox/ -a /function/firefox/firefox/browser -f /function/tlscanary/js/worker_common.js /function/tests/content_signature_test.js <<EOF
+{"mode":"wakeup"}
+{"mode":"quit"}
+EOF

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -7,6 +7,7 @@ services:
       # - TEST_FILES_GLOB=content_signature_test.js
       # - TEST_FILES_GLOB=addon_signature_test.js
     volumes:
+      - ./bin/:/function/bin/
       - ./tests/:/function/tests/
       - ./:/function/local/
 


### PR DESCRIPTION
Test running Fx without python to determine whether this is an issue with the tls-canary XPC shell worker and runner or an issue with the containerized lambda env.

expected output:

```sh
root@3f5b7bade062:/function# /function/bin/canary_fx_test.sh 
set -o pipefail

/function/firefox/firefox/firefox -xpcshell -g /function/firefox/firefox/ -a /function/firefox/firefox/browser -f /function/tlscanary/js/work
er_common.js /function/tests/content_signature_test.js <<EOF
{"mode":"wakeup"}
{"mode":"quit"}
EOF
{"id":15024976768322595000,"worker_id":15195759878062414000,"original_cmd":{"mode":"wakeup"},"success":true,"result":"ACK","command_time":162
3345465528,"response_time":1623345465533}
{"id":1309935440028072000,"worker_id":15195759878062414000,"original_cmd":{"mode":"quit"},"success":true,"result":"ACK","command_time":162334
5465533,"response_time":1623345465533}
```